### PR TITLE
build(deps): Bump 12 backend dependencies (minor+patch)

### DIFF
--- a/apps/api/pyproject.toml
+++ b/apps/api/pyproject.toml
@@ -20,8 +20,8 @@ Repository = "https://github.com/jgouviergmail/LIA-Assistant"
 dev = [
     # Linting & Formatting
     "black==26.3.1",
-    "ruff==0.15.8",
-    "mypy==1.19.1",
+    "ruff==0.15.9",
+    "mypy==1.20.0",
     # Testing
     "pytest==9.0.2",
     "pytest-asyncio==1.3.0",

--- a/apps/api/requirements-dev.txt
+++ b/apps/api/requirements-dev.txt
@@ -2,8 +2,8 @@
 
 # Linting & Formatting
 black==26.3.1
-ruff==0.15.8
-mypy==1.19.1
+ruff==0.15.9
+mypy==1.20.0
 
 # Testing
 pytest==9.0.2

--- a/apps/api/requirements.txt
+++ b/apps/api/requirements.txt
@@ -1,9 +1,9 @@
 # Core Framework
-fastapi==0.135.2
-uvicorn[standard]==0.42.0
+fastapi==0.135.3
+uvicorn[standard]==0.44.0
 
 # Database
-sqlalchemy[asyncio]==2.0.48
+sqlalchemy[asyncio]==2.0.49
 asyncpg==0.31.0
 psycopg[binary]==3.3.3  # PostgreSQL adapter v3 (modern, for LangGraph checkpointer & SQLAlchemy)
 alembic==1.18.4
@@ -25,7 +25,7 @@ tzdata==2026.1  # IANA timezone database for Windows/Python 3.9+
 # Authentication & Security
 python-jose[cryptography]==3.5.0  # CVE-2024-33663 fix (algorithm confusion)
 passlib[bcrypt]==1.7.4
-python-multipart==0.0.22  # CVE-2024-53981, CVE-2026-24486 fixes (DoS)
+python-multipart==0.0.24  # CVE-2024-53981, CVE-2026-24486 fixes (DoS)
 cryptography==46.0.7  # CVE-2024-12797, CVE-2026-26007 fixes
 
 # Observability
@@ -36,7 +36,7 @@ opentelemetry-sdk==1.40.0
 opentelemetry-instrumentation-fastapi==0.61b0
 opentelemetry-exporter-otlp==1.40.0
 prometheus-client==0.24.1
-langfuse==4.0.2  # Phase 6 - LLM Observability
+langfuse==4.0.6  # Phase 6 - LLM Observability
 
 # Rate Limiting
 slowapi==0.1.9
@@ -62,13 +62,13 @@ apscheduler==3.11.2
 
 # AI/ML Stack - LangChain/LangGraph 1.0.x ecosystem
 langchain-core==1.2.28
-langchain==1.2.13  # Updated 2026-03-09 for ecosystem upgrade (merge_lists fix, SummarizationMiddleware, ContextOverflowError)
+langchain==1.2.15  # Updated 2026-03-09 for ecosystem upgrade (merge_lists fix, SummarizationMiddleware, ContextOverflowError)
 langchain-text-splitters==1.1.1  # RecursiveCharacterTextSplitter for RAG Spaces document chunking
 langchain-openai==1.1.12
 openai==2.30.0  # Requis par langchain-openai 1.1.10 (pin 2.14.0 levé — gardes adapter L229-239 protègent input_items)
-langgraph==1.1.3
+langgraph==1.1.6
 langgraph-checkpoint==4.0.1  # Pinné explicitement (transitif de langgraph, reproductibilité builds)
-langgraph-prebuilt==1.0.8  # Pinné explicitement (requis par langgraph 1.0.10)
+langgraph-prebuilt==1.0.9  # Pinné explicitement (requis par langgraph 1.0.10)
 langgraph-checkpoint-postgres==3.0.5
 tiktoken==0.12.0
 
@@ -82,7 +82,7 @@ networkx==3.6.1  # Dependency graph for semantic type expansion
 langchain-deepseek==1.0.1  # DeepSeek V3/R1 models
 langchain-anthropic==1.4.0  # Claude models (auto-compaction, effort="max" sans beta, cache_control fix)
 langchain-google-genai==4.2.1  # Gemini models
-anthropic==0.86.0  # Anthropic SDK (Claude Opus 4.6, structured outputs natifs, cache control GA)
+anthropic==0.89.0  # Anthropic SDK (Claude Opus 4.6, structured outputs natifs, cache control GA)
 
 # MCP (Model Context Protocol) — evolution F2
 mcp>=1.20.0,<2.0.0  # MCP 1.20+ adds list_resources/read_resource (MCP Apps support). Requires starlette>=0.27

--- a/apps/api/src/core/i18n.py
+++ b/apps/api/src/core/i18n.py
@@ -155,11 +155,11 @@ def get_language_from_header(accept_language: str | None) -> Language:
 
         # Try exact match first (for zh-CN)
         if lang in SUPPORTED_LANGUAGES:
-            return lang  # type: ignore[return-value]
+            return lang
 
         # Try with only first 2 chars (for en-US -> en)
         lang_short = lang[:2].lower()
         if lang_short in SUPPORTED_LANGUAGES:
-            return lang_short  # type: ignore[return-value]
+            return lang_short
 
     return DEFAULT_LANGUAGE

--- a/apps/api/src/core/i18n_dates.py
+++ b/apps/api/src/core/i18n_dates.py
@@ -236,6 +236,6 @@ def _extract_language(locale: str | None) -> Language:
 
     # Validate it's a supported language
     if lang in DAY_NAMES:
-        return lang  # type: ignore[return-value]
+        return lang
 
     return DEFAULT_LANGUAGE

--- a/apps/api/src/core/i18n_drafts.py
+++ b/apps/api/src/core/i18n_drafts.py
@@ -602,7 +602,7 @@ def _normalize_language(language: str | None) -> Language:
 
     # Check if supported
     if base_lang in DRAFT_SUCCESS_MESSAGES:
-        return base_lang  # type: ignore[return-value]
+        return base_lang
 
     return DEFAULT_LANGUAGE
 

--- a/apps/api/src/core/i18n_hitl.py
+++ b/apps/api/src/core/i18n_hitl.py
@@ -2130,7 +2130,7 @@ def get_user_language(
     if user_language:
         normalized = HitlMessages._normalize_language(user_language)
         if normalized in SUPPORTED_LANGUAGES:
-            return normalized  # type: ignore[return-value]
+            return normalized
 
     # Priority 2: Accept-Language header
     if accept_language_header:


### PR DESCRIPTION
## Summary
- Bumps 12 backend dependencies (from original Dependabot PR #79)
- Resolves conflict with langchain-core 1.2.28 (merged via #83)
- Fixes mypy 1.20.0 unused-ignore errors (5 `# type: ignore[return-value]` removed)

### Updated packages
| Package | From | To |
|---------|------|----|
| fastapi | 0.135.2 | 0.135.3 |
| uvicorn | 0.42.0 | 0.44.0 |
| sqlalchemy | 2.0.48 | 2.0.49 |
| python-multipart | 0.0.22 | 0.0.24 |
| langfuse | 4.0.2 | 4.0.6 |
| langchain | 1.2.13 | 1.2.15 |
| langgraph | 1.1.3 | 1.1.6 |
| langgraph-prebuilt | 1.0.8 | 1.0.9 |
| anthropic | 0.86.0 | 0.89.0 |
| ruff | 0.15.8 | 0.15.9 |
| mypy | 1.19.1 | 1.20.0 |

### Security
- Resolves Dependabot alerts #39, #40 (anthropic CVE-2026-34450, CVE-2026-34452)

## Test plan
- [x] All 14 CI checks passed on rebased branch (Lint Backend, Test Backend, Docker Build, CodeQL, Trivy, etc.)
- [x] mypy 1.20.0 type narrowing verified — `unused-ignore` errors fixed

🤖 Generated with [Claude Code](https://claude.com/claude-code)