### PR TITLE
build(deps): Vague 2 — backend minor/patch (supersedes #97, #98)

### DIFF
--- a/apps/api/pyproject.toml
+++ b/apps/api/pyproject.toml
@@ -20,10 +20,10 @@ Repository = "https://github.com/jgouviergmail/LIA-Assistant"
 dev = [
     # Linting & Formatting
     "black==26.3.1",
-    "ruff==0.15.9",
-    "mypy==1.20.0",
+    "ruff==0.15.10",
+    "mypy==1.20.1",
     # Testing
-    "pytest==9.0.2",
+    "pytest==9.0.3",
     "pytest-asyncio==1.3.0",
     "pytest-cov==7.1.0",
     "pytest-mock==3.15.1",

--- a/apps/api/requirements-dev.txt
+++ b/apps/api/requirements-dev.txt
@@ -2,11 +2,11 @@
 
 # Linting & Formatting
 black==26.3.1
-ruff==0.15.9
-mypy==1.20.0
+ruff==0.15.10
+mypy==1.20.1
 
 # Testing
-pytest==9.0.2
+pytest==9.0.3
 pytest-asyncio==1.3.0
 pytest-cov==7.1.0
 pytest-mock==3.15.1

--- a/apps/api/requirements.txt
+++ b/apps/api/requirements.txt
@@ -14,7 +14,7 @@ redis==7.4.0
 
 # Configuration
 python-dotenv==1.2.2
-pydantic==2.12.5
+pydantic==2.13.0
 jinja2==3.1.6  # Template engine for orchestration queries
 pydantic-settings==2.13.1
 pyyaml>=6.0  # YAML parsing for SKILL.md files (agentskills.io standard)
@@ -25,18 +25,18 @@ tzdata==2026.1  # IANA timezone database for Windows/Python 3.9+
 # Authentication & Security
 python-jose[cryptography]==3.5.0  # CVE-2024-33663 fix (algorithm confusion)
 passlib[bcrypt]==1.7.4
-python-multipart==0.0.24  # CVE-2024-53981, CVE-2026-24486 fixes (DoS)
+python-multipart==0.0.26  # CVE-2024-53981, CVE-2026-24486 fixes (DoS)
 cryptography==46.0.7  # CVE-2024-12797, CVE-2026-26007 fixes
 
 # Observability
 structlog==25.5.0
 geoip2==5.2.0  # IP geolocation (DB-IP Lite MMDB — free, CC-BY-4.0)
-opentelemetry-api==1.40.0
-opentelemetry-sdk==1.40.0
-opentelemetry-instrumentation-fastapi==0.61b0
-opentelemetry-exporter-otlp==1.40.0
-prometheus-client==0.24.1
-langfuse==4.0.6  # Phase 6 - LLM Observability
+opentelemetry-api==1.41.0
+opentelemetry-sdk==1.41.0
+opentelemetry-instrumentation-fastapi==0.62b0
+opentelemetry-exporter-otlp==1.41.0
+prometheus-client==0.25.0
+langfuse==4.2.0  # Phase 6 - LLM Observability
 
 # Rate Limiting
 slowapi==0.1.9
@@ -65,7 +65,7 @@ langchain-core==1.2.28
 langchain==1.2.15  # Updated 2026-03-09 for ecosystem upgrade (merge_lists fix, SummarizationMiddleware, ContextOverflowError)
 langchain-text-splitters==1.1.1  # RecursiveCharacterTextSplitter for RAG Spaces document chunking
 langchain-openai==1.1.12
-openai==2.30.0  # Requis par langchain-openai 1.1.10 (pin 2.14.0 levé — gardes adapter L229-239 protègent input_items)
+openai==2.31.0  # Requis par langchain-openai 1.1.10 (pin 2.14.0 levé — gardes adapter L229-239 protègent input_items)
 langgraph==1.1.6
 langgraph-checkpoint==4.0.1  # Pinné explicitement (transitif de langgraph, reproductibilité builds)
 langgraph-prebuilt==1.0.9  # Pinné explicitement (requis par langgraph 1.0.10)
@@ -82,7 +82,7 @@ networkx==3.6.1  # Dependency graph for semantic type expansion
 langchain-deepseek==1.0.1  # DeepSeek V3/R1 models
 langchain-anthropic==1.4.0  # Claude models (auto-compaction, effort="max" sans beta, cache_control fix)
 langchain-google-genai==4.2.1  # Gemini models
-anthropic==0.89.0  # Anthropic SDK (Claude Opus 4.6, structured outputs natifs, cache control GA)
+anthropic==0.94.0  # Anthropic SDK (Claude Opus 4.6, structured outputs natifs, cache control GA)
 
 # MCP (Model Context Protocol) — evolution F2
 mcp>=1.20.0,<2.0.0  # MCP 1.20+ adds list_resources/read_resource (MCP Apps support). Requires starlette>=0.27
@@ -91,7 +91,7 @@ mcp>=1.20.0,<2.0.0  # MCP 1.20+ adds list_resources/read_resource (MCP Apps supp
 playwright==1.58.0  # Headless Chromium for web interaction via accessibility tree
 
 # Push Notifications
-firebase-admin==7.3.0  # Firebase Cloud Messaging for push notifications
+firebase-admin==7.4.0  # Firebase Cloud Messaging for push notifications
 pytz==2026.1.post1  # Timezone handling for reminders
 
 # Channels — Multi-Channel Messaging (evolution F3)


### PR DESCRIPTION
## Summary
- Consolidates Dependabot PRs #97 (backend minor/patch group, 14 updates) and #98 (pytest patch)
- Includes CVE fix for python-multipart (DoS), SDK bumps for anthropic/openai/langfuse, and observability stack upgrade

## Dependencies (runtime)
- pydantic 2.12.5 → 2.13.0
- python-multipart 0.0.24 → 0.0.26 (CVE-2024-53981, CVE-2026-24486)
- opentelemetry-api/sdk/exporter 1.40.0 → 1.41.0
- opentelemetry-instrumentation-fastapi 0.61b0 → 0.62b0
- prometheus-client 0.24.1 → 0.25.0
- langfuse 4.0.6 → 4.2.0
- openai 2.30.0 → 2.31.0
- anthropic 0.89.0 → 0.94.0
- firebase-admin 7.3.0 → 7.4.0

## Dependencies (dev)
- ruff 0.15.9 → 0.15.10, mypy 1.20.0 → 1.20.1, pytest 9.0.2 → 9.0.3

## Risk analysis (evidence-based)
- pydantic 2.13: verified no `Field(discriminator=)` or `serialize_as_any` usage
- anthropic 0.94: deprecated client-side compaction helpers — not used (own implementation in `compaction_service.py`)
- langfuse 4.2: additive only (custom span exporter)
- openai 2.31: additive only

## Test plan
- [ ] CI: lint backend + test backend + Docker build
- [ ] Docker dev: rebuild api image, verify health endpoint
- [ ] Runtime: send agent chat message, verify streaming SSE
- [ ] Observability: verify Langfuse traces + Prometheus metrics still exposed

## Rollback
\`git revert <merge-sha>\` — no schema/migration changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)