### PR TITLE
fix(security): patch protobufjs CVE + langchain SSRF fixes (supersedes #101, #102)

### DIFF
--- a/apps/api/requirements.txt
+++ b/apps/api/requirements.txt
@@ -61,10 +61,10 @@ sherpa-onnx>=1.10.0
 apscheduler==3.11.2
 
 # AI/ML Stack - LangChain/LangGraph 1.0.x ecosystem
-langchain-core==1.2.28
+langchain-core==1.2.31
 langchain==1.2.15  # Updated 2026-03-09 for ecosystem upgrade (merge_lists fix, SummarizationMiddleware, ContextOverflowError)
-langchain-text-splitters==1.1.1  # RecursiveCharacterTextSplitter for RAG Spaces document chunking
-langchain-openai==1.1.12
+langchain-text-splitters==1.1.2  # RecursiveCharacterTextSplitter for RAG Spaces document chunking
+langchain-openai==1.1.14
 openai==2.31.0  # Requis par langchain-openai 1.1.10 (pin 2.14.0 levé — gardes adapter L229-239 protègent input_items)
 langgraph==1.1.6
 langgraph-checkpoint==4.0.1  # Pinné explicitement (transitif de langgraph, reproductibilité builds)

--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
       "picomatch": "4.0.4",
       "brace-expansion": "2.0.2",
       "vite": "7.3.2",
-      "defu": "6.1.5"
+      "defu": "6.1.5",
+      "protobufjs": "^7.5.5"
     }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,6 +10,7 @@ overrides:
   brace-expansion: 2.0.2
   vite: 7.3.2
   defu: 6.1.5
+  protobufjs: ^7.5.5
 
 importers:
 
@@ -3715,8 +3716,8 @@ packages:
   property-information@7.1.0:
     resolution: {integrity: sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==}
 
-  protobufjs@7.5.4:
-    resolution: {integrity: sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==}
+  protobufjs@7.5.5:
+    resolution: {integrity: sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg==}
     engines: {node: '>=12.0.0'}
 
   punycode@2.3.1:
@@ -5166,7 +5167,7 @@ snapshots:
     dependencies:
       lodash.camelcase: 4.3.0
       long: 5.3.2
-      protobufjs: 7.5.4
+      protobufjs: 7.5.5
       yargs: 17.7.2
 
   '@headlessui/react@2.2.10(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
@@ -8418,7 +8419,7 @@ snapshots:
 
   property-information@7.1.0: {}
 
-  protobufjs@7.5.4:
+  protobufjs@7.5.5:
     dependencies:
       '@protobufjs/aspromise': 1.1.2
       '@protobufjs/base64': 1.1.2


### PR DESCRIPTION
## Summary
Patches 3 Dependabot security alerts in a single PR.

## Security fixes

### Alert #53 — protobufjs (CRITICAL)
- **Vulnerability:** Arbitrary code execution in protobufjs < 7.5.5
- **Fix:** pnpm override `"protobufjs": "^7.5.5"` in root package.json
- **Chain:** firebase → @firebase/firestore → @grpc/proto-loader → protobufjs
- **Exposure:** Zero direct usage — purely transitive dependency

### Alert #51 — langchain-text-splitters (MEDIUM)
- **Vulnerability:** HTMLHeaderTextSplitter.split_text_from_url SSRF Redirect Bypass
- **Fix:** 1.1.1 → 1.1.2
- **Exposure:** Zero — we only use `RecursiveCharacterTextSplitter` with local text, never `HTMLHeaderTextSplitter` or URL-based splitting

### Alert #52 — langchain-openai (LOW)
- **Vulnerability:** Image token counting SSRF via DNS rebinding
- **Fix:** 1.1.12 → 1.1.14
- **Exposure:** Zero — we don't use image token counting (token counting via tiktoken/Anthropic SDK). Vision uses base64 data URLs, not remote URLs

## Validation
- [x] `tsc --noEmit`: 0 errors
- [x] `vitest run`: 14/14 passing
- [x] protobufjs resolved to 7.5.5 (verified via `pnpm why`)
- [ ] Docker rebuild (api + web) + agent chat test

## Test plan
- [ ] API health endpoint responds
- [ ] Agent chat streaming works (validates langchain-openai 1.1.14)
- [ ] No import errors in API logs (validates langchain-text-splitters 1.1.2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)