### PR TITLE
build(deps): Vague B — GitHub Actions group (supersedes #103)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,7 +84,7 @@ jobs:
           python -m cyclonedx_py requirements requirements.txt --of json -o ../../sbom-backend.json
 
       - name: Upload SBOM artifact
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: sbom
           path: sbom-backend.json
@@ -119,7 +119,7 @@ jobs:
           echo "EOF" >> $GITHUB_OUTPUT
 
       - name: Create Release
-        uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2.6.1
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
         with:
           generate_release_notes: true
           files: sbom-backend.json

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -25,16 +25,16 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@c10b8064de6f491fea524254123dbe5e09572f13 # v4
+        uses: github/codeql-action/init@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4
         with:
           languages: ${{ matrix.language }}
           config-file: .github/codeql/codeql-config.yml
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@c10b8064de6f491fea524254123dbe5e09572f13 # v4
+        uses: github/codeql-action/autobuild@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4
 
       - name: Perform Analysis
-        uses: github/codeql-action/analyze@c10b8064de6f491fea524254123dbe5e09572f13 # v4
+        uses: github/codeql-action/analyze@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4
         with:
           category: "/language:${{ matrix.language }}"
 
@@ -96,7 +96,7 @@ jobs:
           severity: CRITICAL,HIGH
 
       - name: Upload Trivy results
-        uses: github/codeql-action/upload-sarif@c10b8064de6f491fea524254123dbe5e09572f13 # v4
+        uses: github/codeql-action/upload-sarif@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4
         if: always()
         with:
           sarif_file: trivy-results.sarif
@@ -125,7 +125,7 @@ jobs:
           cyclonedx-py environment -o sbom-backend.json --output-format json
 
       - name: Upload SBOM
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: sbom-backend
           path: ./apps/api/sbom-backend.json


### PR DESCRIPTION
## Summary
Rebased PR #103 on current main (original PR failed CI due to stale lockfile).

## Actions updated
| Action | Old | New | Type |
|---|---|---|---|
| pnpm/action-setup | v5.0.0 | v6.0.0 | Major (pnpm 11 support, backwards compat v10) |
| actions/upload-artifact | v7.0.0 | v7.0.1 | Patch (docs only) |
| softprops/action-gh-release | v2.6.1 | v3.0.0 | Major (Node 24 runtime) |
| github/codeql-action | v4.35.1 | v4.35.2 | Patch (perf, bugfixes) |

## Risk assessment
- All runners use `ubuntu-latest` → Node 24 supported ✅
- `packageManager: pnpm@10.18.3` → compatible with action-setup v6 ✅
- All actions pinned to commit SHAs (supply chain security) ✅
- No `CODEQL_ACTION_CLEANUP_TRAP_CACHES` usage to migrate ✅

## Test plan
- [x] CI runs on this PR itself validate the new action versions
- [ ] Verify all 14 CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)