### PR TITLE
docs(adr): reconstitute the 6 founding ADRs, resolve ADR-007 conflict

### DIFF
--- a/docs/architecture/ADR-001-LangGraph-Orchestration.md
+++ b/docs/architecture/ADR-001-LangGraph-Orchestration.md
@@ -1,0 +1,53 @@
+# ADR-001: LangGraph pour Orchestration Multi-Agents
+
+**Status**: ✅ ACCEPTED (2025-10-15) — toujours en vigueur (vérifié 2026-07-21)
+**Deciders**: Équipe architecture LIA
+**Technical Story**: Fondation de l'orchestration conversationnelle
+
+> **Note de provenance (2026-07-21)** : ce fichier a été **reconstitué** à partir du
+> résumé porté par `ADR_INDEX.md`. L'ADR original n'avait jamais été committé
+> (`git log --diff-filter=A` vide) alors que l'index le référençait. Le contenu
+> ci-dessous développe ce résumé et a été confirmé contre le code courant
+> (LangGraph est la dépendance d'orchestration, cf. `requirements.txt` et
+> `src/domains/agents/`). Les dates d'origine sont celles du résumé.
+
+---
+
+## Context and Problem Statement
+
+LIA doit orchestrer des agents conversationnels multi-tours avec état persistant,
+reprise après interruption (HITL) et streaming SSE. Le besoin : un moteur qui gère
+un graphe d'exécution avec cycles, checkpoints et interruptions, sans réinventer la
+gestion d'état.
+
+## Decision
+
+Utiliser **LangGraph** comme moteur d'orchestration des agents.
+
+L'état conversationnel est un `TypedDict` (`MessagesState`) checkpointé en PostgreSQL ;
+les interruptions HITL passent par le pattern `interrupt()` ; le streaming des tokens
+remonte via SSE.
+
+## Alternatives Considered
+
+- ❌ **LangChain seul** — pas de gestion d'état de graphe ni de cycles.
+- ❌ **Orchestration maison** — réinventer checkpoints, reprise et interruptions.
+- ✅ **LangGraph** — state management + cycles conditionnels + checkpoints natifs.
+
+## Consequences
+
+- ✅ Persistance d'état via checkpoints PostgreSQL (reprise de conversation).
+- ✅ HITL via le pattern `interrupt()` (approbations avant exécution).
+- ✅ Streaming SSE des réponses.
+- ⚠️ Courbe d'apprentissage LangGraph et couplage au framework (versions pinnées).
+
+## Metrics (à l'acceptation)
+
+- Sauvegarde de checkpoint : P95 < 50 ms.
+- Chargement de checkpoint : P95 < 100 ms.
+- Taille d'état moyenne : ~15 Ko / conversation.
+
+## Related
+
+- [ADR_INDEX.md](./ADR_INDEX.md) · architecture LangGraph détaillée : [ARCHITECTURE_LANGRAPH.md](../ARCHITECTURE_LANGRAPH.md)
+- [ADR-022](./ADR_INDEX.md#adr-022-langgraph-state--checkpointing) (state & checkpointing)

--- a/docs/architecture/ADR-002-BFF-Pattern-Authentication.md
+++ b/docs/architecture/ADR-002-BFF-Pattern-Authentication.md
@@ -1,0 +1,52 @@
+# ADR-002: BFF Pattern pour Authentication
+
+**Status**: ✅ ACCEPTED (2025-10-20) — toujours en vigueur (vérifié 2026-07-21)
+**Deciders**: Équipe architecture LIA
+**Technical Story**: Sécurisation de l'authentification (v0.1.0 JWT → v0.3.0 BFF)
+
+> **Note de provenance (2026-07-21)** : fichier **reconstitué** depuis le résumé de
+> `ADR_INDEX.md` (l'ADR original n'a jamais été committé). Confirmé contre le code :
+> l'authentification repose sur un cookie de session HTTP-only
+> (`SecuritySettings`, `src/lib/api-client.ts` en `credentials: 'include'`), pas sur
+> des JWT en stockage client. Dates d'origine conservées du résumé.
+
+---
+
+## Context and Problem Statement
+
+L'authentification initiale reposait sur des **JWT stockés côté client**. Trois
+problèmes : vulnérabilité XSS (token en `localStorage`), surcoût de taille (données
+utilisateur embarquées dans chaque token), et révocation impossible (JWT stateless).
+
+## Decision
+
+Adopter le **BFF Pattern** (Backend-For-Frontend) : sessions serveur en Redis,
+identifiées par un **cookie HTTP-only** `SameSite=Lax`.
+
+- Le frontend n'a jamais accès au matériel de session (pas de token en JS).
+- Le cookie porte uniquement un `session_id` ; l'état vit côté serveur (Redis).
+- La révocation est instantanée (suppression de la clé Redis).
+
+## Alternatives Considered
+
+- ❌ **JWT en `localStorage`** — surface XSS, pas de révocation.
+- ❌ **JWT en cookie** — révocation toujours impossible (stateless).
+- ✅ **BFF + sessions Redis** — immunité XSS, révocation instantanée, empreinte réduite.
+
+## Consequences
+
+- ✅ Cookies HTTP-only : immunité XSS sur le matériel d'auth.
+- ✅ `SameSite=Lax` : protection CSRF.
+- ✅ Révocation instantanée (delete Redis).
+- ✅ ~90 % de mémoire en moins (session_id seul vs données embarquées).
+- ⚠️ État serveur requis (Redis) — dépendance d'infrastructure sur le chemin d'auth.
+
+## Metrics (à l'acceptation)
+
+- Empreinte mémoire : 1,2 Mo → 120 Ko (~90 % de réduction).
+- Lookup de session : P95 < 5 ms (Redis).
+- Score sécurité : B+ → A (OWASP 2024).
+
+## Related
+
+- [ADR_INDEX.md](./ADR_INDEX.md) · [AUTHENTICATION.md](../technical/AUTHENTICATION.md) (détail BFF, sessions, cookies)

--- a/docs/architecture/ADR-003-Multi-Domain-Dynamic-Filtering.md
+++ b/docs/architecture/ADR-003-Multi-Domain-Dynamic-Filtering.md
@@ -1,0 +1,60 @@
+# ADR-003: Multi-Domain Dynamic Filtering
+
+**Status**: ✅ ACCEPTED (2025-11-09, finalisé 2025-11-11) — principe toujours en vigueur, implémentation évoluée (vérifié 2026-07-21)
+**Deciders**: Équipe architecture LIA
+**Technical Story**: Maîtrise du coût de prompt au scaling multi-domaines
+
+> **Note de provenance (2026-07-21)** : fichier **reconstitué** depuis le résumé de
+> `ADR_INDEX.md` (original jamais committé). Le principe — ne charger que le
+> catalogue d'outils pertinent — est toujours actif, mais l'implémentation a évolué
+> vers des **stratégies de filtrage** (`services/catalogue/strategies/` :
+> `normal_filtering.py`, `panic_filtering.py`) plutôt que le « hybrid pattern »
+> décrit à l'origine. Contenu confirmé contre le code courant à cette date.
+
+---
+
+## Context and Problem Statement
+
+Le catalogue d'outils grandit avec les domaines : ~3 outils (contacts seuls) →
+30+ outils (10 domaines). Charger tout le catalogue dans le prompt à chaque requête
+multiplie la taille du prompt (~10×) et le coût (~10×). Il faut ne charger que ce
+qui est pertinent pour la requête.
+
+## Decision
+
+Filtrer dynamiquement le catalogue **par domaine détecté**, avec repli sûr :
+
+1. Le router détecte les domaines pertinents (ex. `["contacts", "email"]`).
+2. Le catalogue est filtré aux outils de ces domaines (8 au lieu de 30+).
+3. **Fallback** vers le catalogue complet si la confiance de détection est basse.
+
+## Alternatives Considered
+
+- ❌ **Catalogue complet systématique** — explosion de tokens et de coût.
+- ❌ **Filtrage statique par règles** — non générique, à maintenir par domaine.
+- ✅ **Filtrage dynamique + fallback** — générique (aucun code par domaine), sûr.
+
+## Consequences
+
+- ✅ Réduction de tokens : 60-90 % mesurée.
+- ✅ Architecture générique : un nouveau domaine n'exige aucun changement de code de filtrage.
+- ✅ Sûr : fallback sur confiance basse + métriques.
+- ⚠️ Dépend de la qualité de détection de domaine (d'où le fallback).
+
+## Évolution depuis l'acceptation
+
+Le filtrage est aujourd'hui porté par des stratégies explicites sous
+`src/domains/agents/services/catalogue/strategies/` (`normal_filtering`,
+`panic_filtering`), intégrées à l'analyse de requête LLM-native — et non plus par le
+« hybrid pattern » router→planner décrit initialement. Le principe (charger le
+minimum pertinent, se rabattre sur le complet en cas de doute) est inchangé.
+
+## Metrics (à l'acceptation)
+
+- Taille de catalogue : 30 outils → 5-8 (73-83 % de réduction).
+- Taux de cache : ~35 % (TTL 5 min).
+- Fallback confiance basse : < 10 %.
+
+## Related
+
+- [ADR_INDEX.md](./ADR_INDEX.md) · [SEMANTIC_ROUTER.md](../technical/SEMANTIC_ROUTER.md) · [SMART_SERVICES.md](../technical/SMART_SERVICES.md)

--- a/docs/architecture/ADR-004-Analytical-Reasoning-Patterns.md
+++ b/docs/architecture/ADR-004-Analytical-Reasoning-Patterns.md
@@ -1,0 +1,44 @@
+# ADR-004: Analytical Reasoning Patterns (Planner)
+
+**Status**: ✅ ACCEPTED (2025-11-10) — principe intégré au planner courant (vérifié 2026-07-21)
+**Deciders**: Équipe architecture LIA
+**Technical Story**: Qualité des plans générés par le planner
+
+> **Note de provenance (2026-07-21)** : fichier **reconstitué** depuis le résumé de
+> `ADR_INDEX.md` (original jamais committé). Le résumé parle de « Planner v5 » : il
+> s'agit de la version du **prompt** planner de l'époque, à ne pas confondre avec le
+> nœud courant `planner_node_v3.py` (versioning distinct). Le principe décrit —
+> raisonnement analytique en phases avant génération du plan — est intégré au
+> planner actuel et à ses prompts versionnés. Dates d'origine conservées.
+
+---
+
+## Context and Problem Statement
+
+Les versions antérieures du prompt planner produisaient des plans trop simplistes :
+peu de raisonnement analytique, pas de décomposition explicite de l'intention
+utilisateur. Résultat : des plans qui échouaient et devaient être rejoués.
+
+## Decision
+
+Structurer le raisonnement du planner en **phases analytiques explicites** avant la
+génération de l'`ExecutionPlan` :
+
+1. **Analyse de l'intention** — quoi (WHAT) et pourquoi (WHY).
+2. **Décomposition** en sous-tâches.
+3. **Génération** de l'`ExecutionPlan` avec justifications par étape.
+
+## Alternatives Considered
+
+- ❌ **Plan direct sans analyse** — plans simplistes, taux de rejeu élevé.
+- ✅ **Enrichissement progressif + analyse structurée** — meilleure qualité de plan.
+
+## Consequences
+
+- ✅ Qualité de plan : ~+25 % (mesure via taux d'approbation HITL).
+- ✅ Succès au rejeu : ~80 % (contre ~60 %).
+- ⚠️ Latence : ~+300 ms (compromis accepté pour la qualité).
+
+## Related
+
+- [ADR_INDEX.md](./ADR_INDEX.md) · [PLANNER.md](../technical/PLANNER.md) (planner courant, prompts versionnés)

--- a/docs/architecture/ADR-005-Sequential-Fallback-Execution.md
+++ b/docs/architecture/ADR-005-Sequential-Fallback-Execution.md
@@ -1,0 +1,45 @@
+# ADR-005: Sequential Fallback Execution
+
+**Status**: ✅ IMPLEMENTED (2025-11-14) — toujours en vigueur (vérifié 2026-07-21)
+**Deciders**: Équipe architecture LIA
+**Technical Story**: Éviter l'exécution parallèle des branches conditionnelles d'un plan
+
+> **Note de provenance (2026-07-21)** : fichier **reconstitué** depuis le résumé de
+> `ADR_INDEX.md` (original jamais committé). Confirmé contre le code : le filtrage
+> des étapes ignorées avant exécution vit dans
+> `src/domains/agents/orchestration/parallel_executor.py`. Dates d'origine conservées.
+
+---
+
+## Context and Problem Statement
+
+L'exécuteur parallèle lançait toutes les étapes d'une vague via `asyncio.gather()`,
+y compris les branches de **fallback conditionnel**. Conséquence : le plan principal
+ET son fallback s'exécutaient en parallèle — double appel API, double coût, et
+comportement non déterministe.
+
+## Decision
+
+**Filtrer les étapes ignorées (skipped) AVANT** `asyncio.gather()`, pour n'exécuter
+que la vague réellement retenue :
+
+```python
+skipped_steps = _identify_skipped_steps(execution_plan, completed_steps)
+next_wave_filtered = next_wave - skipped_steps
+step_results = await asyncio.gather(*[... for step_id in next_wave_filtered])
+```
+
+## Alternatives Considered
+
+- ❌ **Exécuter puis ignorer les résultats fallback** — coût et appels API déjà payés.
+- ✅ **Filtrer avant `gather`** — aucune exécution superflue, déterministe.
+
+## Consequences
+
+- ✅ Réduction de coût : ~50 % sur les plans comportant un fallback.
+- ✅ Déterminisme : plus de course entre branche principale et fallback.
+- ✅ Observabilité : métrique `langgraph_plan_steps_skipped_total`.
+
+## Related
+
+- [ADR_INDEX.md](./ADR_INDEX.md) · [GRAPH_AND_AGENTS_ARCHITECTURE.md](../technical/GRAPH_AND_AGENTS_ARCHITECTURE.md) (parallel_executor)

--- a/docs/architecture/ADR-006-Prevent-Unbounded-List-Operations.md
+++ b/docs/architecture/ADR-006-Prevent-Unbounded-List-Operations.md
@@ -1,0 +1,42 @@
+# ADR-006: Prevent Unbounded List Operations
+
+**Status**: ✅ IMPLEMENTED (2025-11-14) — toujours en vigueur (vérifié 2026-07-21)
+**Deciders**: Équipe architecture LIA
+**Technical Story**: Éviter l'explosion de tokens sur les opérations de listing sans filtre
+
+> **Note de provenance (2026-07-21)** : fichier **reconstitué** depuis le résumé de
+> `ADR_INDEX.md` (original jamais committé). Confirmé contre le code : le garde-fou
+> de listing vit dans `src/domains/agents/tools/google_contacts_tools.py`. Dates
+> d'origine conservées.
+
+---
+
+## Context and Problem Statement
+
+Le planner pouvait générer `list_contacts(query=None)`, renvoyant l'annuaire complet
+(450+ contacts). Conséquence : explosion de tokens (100k+), coût, et une expérience
+utilisateur dégradée (listes ingérables).
+
+## Decision
+
+Prévention **multi-couches** des listings non bornés :
+
+1. **Validation planner** — avertissement (soft) si `list_contacts` est planifié sans `query`.
+2. **Garde-fou outil** — plafond dur (hard cap) des résultats en l'absence de `query`.
+3. **Logging** — trace d'avertissement pour le débogage.
+
+## Alternatives Considered
+
+- ❌ **Aucune limite** — explosion de tokens, listes ingérables.
+- ❌ **Interdire le listing sans query** — casse des cas d'usage légitimes (petit annuaire).
+- ✅ **Soft warning + hard cap** — protège sans interdire.
+
+## Consequences
+
+- ✅ Gaspillage de ressources : ~-95 % (plafond de résultats vs annuaire complet).
+- ✅ Satisfaction utilisateur : plus de listes écrasantes.
+- ✅ Observabilité : métrique `langgraph_plan_validation_warnings_total`.
+
+## Related
+
+- [ADR_INDEX.md](./ADR_INDEX.md) · [TOOLS.md](../technical/TOOLS.md) · [PLANNER.md](../technical/PLANNER.md)

--- a/docs/architecture/ADR_INDEX.md
+++ b/docs/architecture/ADR_INDEX.md
@@ -5,21 +5,16 @@
 > Format: [MADR](https://adr.github.io/madr/) (Markdown Any Decision Records)
 > Principe: Documenter les décisions importantes pour maintenir la cohérence architecturale
 
-> [!IMPORTANT]
-> **8 entrées de cet index pointent vers des fichiers qui n'existent pas** (vérifié
-> le 2026-07-20 : 135 chemins référencés, 8 absents). Le résumé donné ici reste la
-> seule trace de ces décisions — il n'y a pas de fichier à ouvrir derrière.
+> [!NOTE]
+> **ADR-001 à ADR-006 reconstitués le 2026-07-21.** Ces six ADR fondateurs étaient
+> résumés ici mais n'avaient jamais eu de fichier (`git log --diff-filter=A` vide).
+> Leurs fichiers ont été recréés sous `docs/architecture/` à partir de ce résumé et
+> confirmés contre le code courant ; chacun porte une note de provenance. Les
+> décisions restent en vigueur (implémentation parfois évoluée — voir les fichiers).
 >
-> - `ADR-001` (LangGraph Orchestration) et `ADR-002` (BFF Pattern) : annoncés sous
->   `docs/architecture/`, jamais présents.
-> - `ADR-003` à `ADR-006`, plus deux entrées héritées : annoncés sous
->   `docs/archive/…`, **ce répertoire n'existe pas**.
->
-> Ces fichiers n'apparaissent dans aucun commit (`git log --diff-filter=A` est vide) :
-> ils n'ont jamais été écrits, ils n'ont pas été supprimés. La numérotation réelle
-> des ADR commence donc à **ADR-007**. Les autres documents du dépôt citent
-> néanmoins ADR-001 à ADR-006 et ADR-008 environ 68 fois — ces renvois sont
-> compréhensibles via le résumé ci-dessous, mais ne mènent nulle part.
+> Deux entrées de la section « ADRs Archivés » (Unit of Work *rejeté*, Workflow-Based
+> HITL *déprécié*) n'ont volontairement pas de fichier : le résumé suffit à une
+> décision sans implémentation. Leur pointeur `**Fichier**` l'indique explicitement.
 
 ---
 
@@ -236,7 +231,7 @@ Un **Architecture Decision Record** est un document qui capture une **décision 
 ### ADR-003: Multi-Domain Dynamic Filtering
 
 **Status**: ✅ ACCEPTED (2025-11-09, Finalized 2025-11-11)
-**Fichier**: `docs/archive/architecture/ADR-003-Multi-Domain-Dynamic-Filtering.md`
+**Fichier**: `docs/architecture/ADR-003-Multi-Domain-Dynamic-Filtering.md`
 
 **Décision**: Implémenter **filtrage dynamique par domaine** pour éviter token explosion lors du scaling à 10+ domaines.
 
@@ -264,7 +259,7 @@ Un **Architecture Decision Record** est un document qui capture une **décision 
 ### ADR-004: Analytical Reasoning Patterns (Planner v5)
 
 **Status**: ✅ ACCEPTED (2025-11-10)
-**Fichier**: `docs/archive/architecture/ADR-004-Analytical-Reasoning-Patterns.md`
+**Fichier**: `docs/architecture/ADR-004-Analytical-Reasoning-Patterns.md`
 
 **Décision**: Intégrer **Progressive Enrichment + Structured Analysis** dans Planner prompt v5 pour améliorer qualité des plans.
 
@@ -288,7 +283,7 @@ Un **Architecture Decision Record** est un document qui capture une **décision 
 ### ADR-005: Sequential Fallback Execution
 
 **Status**: ✅ IMPLEMENTED (2025-11-14)
-**Fichier**: `docs/archive/architecture/ADR-005-Sequential-Fallback-Execution.md`
+**Fichier**: `docs/architecture/ADR-005-Sequential-Fallback-Execution.md`
 
 **Décision**: Filtrer steps skipped AVANT `asyncio.gather()` pour éviter exécution parallèle des branches conditionnelles.
 
@@ -318,7 +313,7 @@ step_results = await asyncio.gather(*tasks)
 ### ADR-006: Prevent Unbounded List Operations
 
 **Status**: ✅ IMPLEMENTED (2025-11-14)
-**Fichier**: `docs/archive/architecture/ADR-006-Prevent-Unbounded-List-Operations.md`
+**Fichier**: `docs/architecture/ADR-006-Prevent-Unbounded-List-Operations.md`
 
 **Décision**: Ajouter **soft warnings + hard safeguards** pour prévenir `list_contacts()` sans query (450+ results).
 
@@ -339,39 +334,34 @@ step_results = await asyncio.gather(*tasks)
 
 ---
 
-### ADR-007: Message Windowing Strategy
+### ADR-007: Service Layer Pattern for Node Complexity Reduction
 
-> [!WARNING]
-> **Conflit de numérotation (constaté 2026-07-20).** Le numéro **ADR-007 est
-> utilisé deux fois** : cette entrée (« Message Windowing Strategy », adossée au
-> doc technique `MESSAGE_WINDOWING_STRATEGY.md`) **et** le fichier
-> `docs/architecture/ADR-007-Service-Layer-Pattern-For-Node-Complexity.md`
-> (titre H1 : « Service Layer Pattern for Node Complexity Reduction »). Les liens
-> `#adr-007-service-layer-pattern-for-node-complexity` (p. ex. depuis ADR-127)
-> visent le second. La résolution — renuméroter l'une des deux décisions — est
-> laissée au mainteneur : elle touche l'historique décisionnel et des références
-> croisées, hors du périmètre de ce réalignement documentaire.
+**Status**: ✅ Accepted & Implemented (2025-11-16) — SUPERSEDED par Architecture v3 (Smart Services)
+**Fichier**: `docs/architecture/ADR-007-Service-Layer-Pattern-For-Node-Complexity.md`
 
-**Status**: ✅ ACCEPTED (2025-10-28)
-**Fichier**: Documenté dans `docs/technical/MESSAGE_WINDOWING_STRATEGY.md`
+**Décision**: Extraire la logique des nœuds LangGraph volumineux (router, planner) vers une **couche de services** dédiée pour réduire leur complexité. L'architecture v3 a poussé le pattern plus loin avec les Smart Services (`QueryAnalyzerService`, `SmartPlannerService`, `SmartCatalogueService`) — voir [SMART_SERVICES.md](../technical/SMART_SERVICES.md).
 
-**Décision**: Implémenter **message windowing** avec stratégie par node pour optimiser latency longues conversations.
+> **Conflit de numérotation résolu (2026-07-21).** Le numéro ADR-007 appartient au
+> Service Layer Pattern ci-dessus (fichier réel, référencé par ADR-127). L'entrée
+> « Message Windowing Strategy » qui occupait ce numéro n'était pas un ADR mais une
+> note technique ; elle est déclassée juste en dessous.
 
-**Problème**:
-- Conversations > 50 messages → 100k+ tokens contexte
-- Latency > 10s pour router
-- Cost explosion
+---
 
-**Solution**:
-- Router: 5 turns (messages récents)
-- Planner: 10 turns
-- Response: 20 turns
-- Store pour context business indépendant
+### Note technique — Message Windowing Strategy (pas un ADR)
 
-**Impact**:
-- ✅ E2E latency: -50% (10s → 5s)
-- ✅ Cost: -77% (messages longues)
-- ✅ Quality: Preserved via Store
+> Anciennement catalogué à tort sous « ADR-007 ». Ce n'est pas une décision
+> architecturale distincte mais une **stratégie technique**, documentée dans
+> [`MESSAGE_WINDOWING_STRATEGY.md`](../technical/MESSAGE_WINDOWING_STRATEGY.md).
+> Conservée ici pour la traçabilité.
+
+**Décision**: message windowing par nœud pour réduire la latence des longues conversations.
+
+**Problème**: conversations > 50 messages → 100k+ tokens de contexte, latence router élevée, coût.
+
+**Solution**: fenêtres de messages par nœud (valeurs à jour dans `MESSAGE_WINDOWING_STRATEGY.md` — router et planner héritent de `DEFAULT_MESSAGE_WINDOW_SIZE`, il n'existe pas de variable dédiée par nœud) + Store pour le contexte business.
+
+**Impact**: latence E2E ~-50 %, coût ~-77 % sur longues conversations, qualité préservée via le Store.
 
 ---
 
@@ -2869,7 +2859,7 @@ scheduler.add_job(process_interest_notifications, trigger="interval", minutes=15
 **Status**: ✅ IMPLEMENTED (2026-07-03)
 **Fichier**: `docs/architecture/ADR-094-Remove-Dead-Per-Node-Windowing-Helpers.md`
 
-**Décision**: Suppression d'un micro-sous-système **mort** dans `message_windowing.py` — les helpers `get_router_windowed_messages` / `get_planner_windowed_messages` / `get_orchestrator_windowed_messages` n'avaient **aucun call site** en prod (le router lit `state[STATE_KEY_MESSAGES]` directement), et les 3 settings qui les alimentaient (`router/planner/orchestrator_message_window_size` + constantes + `.env`) n'étaient consommés que par ces helpers morts ; seuls des **tests** les exerçaient encore (fake coverage). Retirés avec leurs settings/constantes/`.env`/tests. **Conservé** ce qui est vivant : `get_windowed_messages` (utilisé par `react_nodes`) et `get_response_windowed_messages` (utilisé par `response_node`) + `response_message_window_size` / `default_message_window_size`. Aucun changement de comportement (la troncature de tokens est déjà bornée par le reducer state-level `add_messages_with_truncate`). Le windowing per-nœud router/planner/orchestrator (vrai levier latence) est **différé au chantier latence**, à réintroduire avec benchmarks de qualité de routage/planification plutôt qu'en scaffolding inutilisé. Application de la règle CLAUDE.md « dead code deleted, not kept for later — wire it or remove it, record in a short ADR ». Complète [ADR-007](#adr-007-service-layer-pattern-for-node-complexity).
+**Décision**: Suppression d'un micro-sous-système **mort** dans `message_windowing.py` — les helpers `get_router_windowed_messages` / `get_planner_windowed_messages` / `get_orchestrator_windowed_messages` n'avaient **aucun call site** en prod (le router lit `state[STATE_KEY_MESSAGES]` directement), et les 3 settings qui les alimentaient (`router/planner/orchestrator_message_window_size` + constantes + `.env`) n'étaient consommés que par ces helpers morts ; seuls des **tests** les exerçaient encore (fake coverage). Retirés avec leurs settings/constantes/`.env`/tests. **Conservé** ce qui est vivant : `get_windowed_messages` (utilisé par `react_nodes`) et `get_response_windowed_messages` (utilisé par `response_node`) + `response_message_window_size` / `default_message_window_size`. Aucun changement de comportement (la troncature de tokens est déjà bornée par le reducer state-level `add_messages_with_truncate`). Le windowing per-nœud router/planner/orchestrator (vrai levier latence) est **différé au chantier latence**, à réintroduire avec benchmarks de qualité de routage/planification plutôt qu'en scaffolding inutilisé. Application de la règle CLAUDE.md « dead code deleted, not kept for later — wire it or remove it, record in a short ADR ». Complète [ADR-007](#adr-007-service-layer-pattern-for-node-complexity-reduction).
 
 ---
 
@@ -3186,7 +3176,7 @@ scheduler.add_job(process_interest_notifications, trigger="interval", minutes=15
 
 **Status**: 🗑️ DEPRECATED (Superseded by ADR-008)
 **Date**: 2025-10-25
-**Fichier**: `docs/archive/adr/ADR_005_REVERTED_LESSONS_LEARNED.md`
+**Fichier**: *(décision archivée — résumée ci-dessous, pas de fichier séparé)*
 
 **Décision originale**: Workflow-based HITL avec interruptions mid-execution.
 
@@ -3207,7 +3197,7 @@ scheduler.add_job(process_interest_notifications, trigger="interval", minutes=15
 ### ADR-001 (Archive): Unit of Work Pattern
 
 **Status**: ❌ REJECTED (2025-09-15)
-**Fichier**: `docs/archive/design/ADR-001-unit-of-work-pattern.md`
+**Fichier**: *(décision archivée — résumée ci-dessous, pas de fichier séparé)*
 
 **Décision**: Utiliser Unit of Work pattern pour transactions database.
 


### PR DESCRIPTION
Follow-up to #214 on the two items left for maintainer arbitration.

## Founding ADRs 001–006 reconstituted
The index summarized these six but no files ever existed (`git log --diff-filter=A` empty). They are recreated under `docs/architecture/` **from the index summaries, confirmed against current code**, each with a provenance note (reconstituted 2026-07-21, original never committed). All six decisions remain in force; implementation evolutions are noted per file (e.g. 003's filtering now via catalogue strategies, 004 folded into the current planner). Metrics cited in 005/006 verified to exist.

## ADR-007 conflict: resolved by declassing, not renumbering
"Message Windowing Strategy" was a technical note wrongly catalogued under 007 — the number belongs to the real file (Service Layer Pattern, referenced by ADR-127). ADR-007 now indexes that file; Message Windowing becomes a non-numbered technical note → `MESSAGE_WINDOWING_STRATEGY.md`. No decision renumbered, no history rewritten. The ADR-127 cross-link now resolves to the correct slug.

## Not reconstituted (deliberate)
The two archived entries — Unit of Work (*rejected*) and Workflow-Based HITL (*deprecated*) — keep only their index summary: no implementation to document, and reconstructing a rejected decision would add noise.

## Result
`ADR_INDEX.md`: **0 dead `**Fichier**` link, 0 broken in-page anchor**. Index warning header updated. Docs-only. The 2 remaining cross-file anchors (ADR-018/019 → `#adr-008`) pre-exist and live inside ADR files (out of this scope).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
