### PR TITLE
feat(mobile): measure native WebView capabilities under production headers

### DIFF
--- a/.github/workflows/mobile-webview-probe.yml
+++ b/.github/workflows/mobile-webview-probe.yml
@@ -1,0 +1,114 @@
+name: Mobile WebView Probe
+
+# Measures what LIA's web app can do inside a NATIVE WebView shell, under the
+# real production security headers, on BOTH engines. The iOS leg exists because
+# WKWebView cannot be measured from the Windows/Linux dev hosts: a GitHub-hosted
+# macOS runner is the only way to get that evidence, and it is free for this
+# public repository.
+#
+# Manual dispatch ONLY. This workflow builds a throwaway Capacitor shell in the
+# runner's temp directory, points it at a local probe server, and asserts LIA's
+# invariants (httpOnly cookie invisible to JS, credentials:'include' carried,
+# SSE, Service Worker, CSP enforced). It never touches production, a store, or
+# a credential.
+#
+# The gate logic lives in `scripts/mobile-probe/` and runs through `task`, so a
+# developer runs the SAME command the runner does (ADR-151).
+
+on:
+  workflow_dispatch:
+    inputs:
+      coep:
+        description: "COEP mode to serve (default = the value production resolves)"
+        required: false
+        default: ""
+      restart:
+        description: "Cold-restart mode for the cookie-persistence check: pause | kill"
+        required: false
+        default: "pause"
+
+permissions:
+  contents: read
+
+jobs:
+  android:
+    name: Android WebView
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Set up Node
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v6
+        with:
+          node-version: "24"
+
+      - name: Set up Task
+        uses: arduino/setup-task@c0bc642852239c2689f73f4ea6459c29405f3c52 # v3.0.0
+        with:
+          version: 3.x
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up JDK
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
+        with:
+          distribution: temurin
+          java-version: "21"
+
+      # KVM is what makes an x86_64 emulator usable on a hosted runner; without
+      # it the boot takes long enough to exhaust the job timeout.
+      - name: Enable KVM
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' \
+            | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+
+      - name: Probe the Android WebView
+        uses: reactivecircus/android-emulator-runner@b530d96654c385303d652368551fb075bc2f0b6b # v2.35.0
+        with:
+          api-level: 36
+          target: google_apis
+          arch: x86_64
+          # Matches the local measurement host: software rendering, no audio,
+          # no snapshot — a restored snapshot would carry a stale cookie store
+          # and quietly invalidate the persistence check.
+          emulator-options: -no-window -no-snapshot -no-boot-anim -no-audio -gpu swiftshader_indirect
+          script: task mobile:probe:android -- --restart ${{ inputs.restart }} --out "${{ github.workspace }}/evidence-android.json" ${{ inputs.coep && format('--coep {0}', inputs.coep) || '' }}
+
+      - name: Upload evidence
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: webview-evidence-android
+          path: evidence-android.json
+          if-no-files-found: warn
+
+  ios:
+    name: iOS WKWebView
+    runs-on: macos-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Set up Node
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v6
+        with:
+          node-version: "24"
+
+      - name: Set up Task
+        uses: arduino/setup-task@c0bc642852239c2689f73f4ea6459c29405f3c52 # v3.0.0
+        with:
+          version: 3.x
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Probe WKWebView
+        run: task mobile:probe:ios -- --restart ${{ inputs.restart }} --out "${{ github.workspace }}/evidence-ios.json" ${{ inputs.coep && format('--coep {0}', inputs.coep) || '' }}
+
+      - name: Upload evidence
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: webview-evidence-ios
+          path: evidence-ios.json
+          if-no-files-found: warn

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -308,6 +308,21 @@ tasks:
     cmds:
       - pnpm test:coverage
 
+  mobile:probe:android:
+    desc: Measure LIA's production headers inside a real Android WebView (needs a booted emulator/device)
+    # The probe imports the CSP/COEP builders from apps/web/src/lib/csp.ts, so
+    # what it measures is what production serves — never a copy that can drift.
+    # MODULE_TYPELESS_PACKAGE_JSON is silenced because apps/web/package.json has
+    # no "type" field: Node still strips the types correctly, the warning is
+    # noise that would drown the evidence.
+    cmds:
+      - node --disable-warning=MODULE_TYPELESS_PACKAGE_JSON scripts/mobile-probe/run.mjs --platform android {{.CLI_ARGS}}
+
+  mobile:probe:ios:
+    desc: Same probe inside WKWebView on an iOS simulator (macOS only — Xcode required)
+    cmds:
+      - node --disable-warning=MODULE_TYPELESS_PACKAGE_JSON scripts/mobile-probe/run.mjs --platform ios {{.CLI_ARGS}}
+
   test:e2e:
     desc: Playwright E2E + axe accessibility journeys (hermetic, mocked API)
     dir: "{{.WEB_DIR}}/e2e"

--- a/scripts/mobile-probe/README.md
+++ b/scripts/mobile-probe/README.md
@@ -1,0 +1,126 @@
+# Native WebView capability probe
+
+Measures what LIA's web app can and cannot do when it runs inside a **native
+WebView shell** (Capacitor), under the **real production security headers**, on
+both engines: Android's Chromium WebView and iOS's WKWebView.
+
+It is a **guard, not a report**. Facts that would silently break the product
+fail the run; immovable platform limits are recorded as evidence instead.
+
+```bash
+task mobile:probe:android          # needs a booted emulator or device
+task mobile:probe:ios              # macOS only (Xcode + simulator)
+
+# options are passed through
+task mobile:probe:android -- --settle 25000 --restart kill --out evidence.json
+```
+
+## Why it exists
+
+The mobile shell architecture rests on a single bet: **the WebView loads the
+remote web origin**, so the httpOnly session cookie, SSE and the whole BFF
+contract keep working unchanged. That bet is only worth making if it is
+measured — on both engines, under the real headers, and again after every
+Capacitor or CSP change.
+
+## No drift by construction
+
+`server.mjs` **imports** `buildAppCsp`, `resolveCoepMode` and `buildHsts` from
+[`apps/web/src/lib/csp.ts`](../../apps/web/src/lib/csp.ts) — the same pure module
+`next.config.ts` and `csp.test.ts` use. Copying the policy here would recreate
+exactly the duplication that module exists to prevent, and a probe measuring a
+stale policy is worse than no probe.
+
+The native project is **generated into the OS temp directory**, never vendored:
+an Android or Xcode project would add thousands of unreviewable files, would
+freeze the very thing being re-measured, and — because `task deploy:prod` rsyncs
+the WORKING TREE, untracked files included — could be shipped to production by
+accident.
+
+## What it asserts
+
+| Assertion | Why it must hold |
+|---|---|
+| Native bridge injected under the production CSP | Capacitor injects out-of-band (`addDocumentStartJavaScript` / `WKUserScript`) and its bundled JS contains no `eval`, so `script-src` should not apply. Asserted rather than assumed. |
+| httpOnly session cookie invisible to JavaScript | LIA's XSS-proof design ([`api-client.ts`](../../apps/web/src/lib/api-client.ts)) depends on it. |
+| `credentials:'include'` carries the session cookie | The BFF contract; the API accepts nothing else ([`session_dependencies.py`](../../apps/api/src/core/session_dependencies.py)). |
+| Cross-site credentialed call keeps its cookie | Production splits the app and the API across two origins, so this is the path every authenticated call takes. See below. |
+| Session cookie survives a cold restart | See the flush hazard below. |
+| SSE streams | The chat rail depends on it. |
+| Service Worker registers | Offline shell, [ADR-146](../../docs/architecture/ADR-146-Offline-PWA.md). |
+| The production CSP is genuinely enforced | A cross-origin `fetch` must be refused. |
+| Voice and geolocation APIs reachable | `useVoiceInput`, `useGeolocation`. |
+
+## Platform limits it records (design inputs, not failures)
+
+Measured on Android 16 / WebView 133, both under `COEP: credentialless` and
+`require-corp`:
+
+- **No Push API and no Notifications API.** Web push cannot work in either
+  WebView, so push must be native on **both** platforms. `UserFCMToken` already
+  carries `device_type ∈ {android, ios, web}`, so no schema change is needed.
+- **No cross-origin isolation, therefore no `SharedArrayBuffer`.** Unchanged by
+  the COEP value — it is not a header choice. `isSherpaKwsSupported()` returns
+  false and voice mode degrades to tap-to-speak, so the **wake word is lost in
+  the shell on Android too**, not only on iOS where it is already lost.
+
+## It replays production's real topology, not a same-origin simplification
+
+Production serves `connect-src 'self' https://lia-back.jeyswork.com …` from
+`https://lia.jeyswork.com`: **the API is a separate origin**, so every
+authenticated call is a cross-origin credentialed request. Measuring only
+same-origin would have left that path unproven.
+
+`buildAppCsp` takes the API URL as a parameter, so the probe passes one and gets
+the production `connect-src` for free. The document is served from `localhost`
+and the API origin from `127.0.0.1` — **distinct sites** for cookie purposes,
+which is *stricter* than production's same-site `lia.` / `lia-back.` split: if
+the cookie survives here, it survives there.
+
+This matters because Android WebView differs from Chrome:
+`CookieManager.setAcceptThirdPartyCookies` defaults to **false**. Capacitor
+enables it unconditionally — `Bridge.create()` → `MockCordovaWebViewImpl.init()`
+→ `CapacitorCordovaCookieManager` → `setAcceptThirdPartyCookies(webView, true)`
+— and the assertion exists to catch that call ever disappearing. Measured
+present on Capacitor 8.5.0.
+
+## The cookie flush hazard
+
+Android WebView writes its cookie store to disk on a **~30 s timer**, and
+Capacitor never calls `CookieManager.flush()`. Measured: a restart 28 s after
+the cookie was set **loses it**; the same restart at 60 s keeps it.
+
+A user who signs in and leaves the app within that window is signed out — the
+most likely moment for someone to background the app. The shell owes a
+`CookieManager.getInstance().flush()` on pause. Reproduce with
+`-- --settle 25000`.
+
+## iOS specifics, established on a generated project
+
+Three assumptions that would each have burned a CI run were checked against a
+real `npx cap add ios` output rather than trusted:
+
+- **Capacitor 8 uses Swift Package Manager, not CocoaPods.** It generates
+  `ios/App/App.xcodeproj` plus `CapApp-SPM/Package.swift`, and **no
+  `.xcworkspace`** — so the build must use `-project`, never `-workspace`.
+- **No scheme is shared.** Schemes appear under `xcuserdata` the first time
+  Xcode opens the project, which never happens on a runner. `run.mjs` asks
+  `xcodebuild -list` and falls back to `-target App`.
+- **`server.cleartext` is Android-only.** Capacitor's iOS platform ignores it
+  and the generated Info.plist has no `NSAppTransportSecurity` key at all, so
+  `scaffold.mjs` adds an exception **scoped to `localhost`** —
+  `NSAllowsArbitraryLoads` would disable ATS app-wide and is never a shape to
+  copy into a shipping shell. The patch is idempotent and CRLF-tolerant.
+
+## Continuous integration
+
+`.github/workflows/mobile-webview-probe.yml` runs both platforms on manual
+dispatch and uploads each evidence JSON. iOS uses a GitHub-hosted `macos-latest`
+runner, free for this public repository — the only way to measure WKWebView
+without a Mac.
+
+## Pinning
+
+`CAPACITOR_VERSION` in `scaffold.mjs` is pinned **exactly**, not ranged: a guard
+whose dependency floats can change its answer without changing its evidence.
+Bumping it is deliberate and must be followed by a fresh run of both platforms.

--- a/scripts/mobile-probe/page.html
+++ b/scripts/mobile-probe/page.html
@@ -1,0 +1,118 @@
+<!doctype html>
+<meta charset="utf-8" />
+<title>LIA WebView capability probe</title>
+<body>
+  <h1>LIA WebView capability probe</h1>
+  <pre id="out">running…</pre>
+  <script>
+    /*
+     * Runs inside the native WebView, under LIA's REAL production security
+     * headers (served by server.mjs, which imports them from
+     * apps/web/src/lib/csp.ts — never a copy).
+     *
+     * Results are POSTed back to the same origin rather than logged: console
+     * forwarding differs between Android (logcat) and iOS (os_log), while a
+     * same-origin POST behaves identically on both AND doubles as proof that
+     * `fetch` works under `connect-src 'self'`.
+     */
+    (async () => {
+      const r = { probe_version: 1 };
+
+      r.ua = navigator.userAgent;
+
+      // --- Native bridge: does it survive the strict CSP? -----------------
+      // Capacitor injects it out-of-band (addDocumentStartJavaScript on
+      // Android, WKUserScript on iOS), so `script-src` should not apply. This
+      // asserts that, rather than trusting it.
+      r.bridge_Capacitor = typeof window.Capacitor;
+      r.bridge_isNative = !!(window.Capacitor?.isNativePlatform?.());
+      r.bridge_platform = window.Capacitor?.getPlatform?.() ?? null;
+
+      // --- Web push: absent in both WebViews, hence native push ------------
+      r.has_Notification = 'Notification' in window;
+      r.has_PushManager = 'PushManager' in window;
+      r.has_serviceWorker = 'serviceWorker' in navigator;
+
+      // --- Wake-word prerequisites (sherpaKws.isSherpaKwsSupported) --------
+      r.crossOriginIsolated = typeof crossOriginIsolated !== 'undefined' ? crossOriginIsolated : null;
+      r.has_SharedArrayBuffer = typeof SharedArrayBuffer !== 'undefined';
+      r.has_WebAssembly = typeof WebAssembly !== 'undefined';
+      r.has_AudioWorklet = typeof AudioContext !== 'undefined' && typeof AudioWorkletNode !== 'undefined';
+
+      // --- Voice / geo / uploads ------------------------------------------
+      r.has_getUserMedia = !!navigator.mediaDevices?.getUserMedia;
+      r.has_MediaRecorder = typeof MediaRecorder !== 'undefined';
+      r.has_geolocation = !!navigator.geolocation;
+
+      // --- BFF invariant: httpOnly cookie must stay invisible to JS -------
+      r.document_cookie = document.cookie;
+
+      // --- Offline shell ---------------------------------------------------
+      try {
+        const reg = await navigator.serviceWorker.register('/sw.js');
+        r.sw_registered = !!reg;
+        r.sw_scope = reg.scope;
+      } catch (e) {
+        r.sw_registered = false;
+        r.sw_error = String(e && e.message);
+      }
+
+      // --- Streaming: the chat rail depends on it --------------------------
+      r.sse = await new Promise(resolve => {
+        let n = 0;
+        const es = new EventSource('/sse');
+        const timer = setTimeout(() => { es.close(); resolve({ ok: false, events: n, reason: 'timeout' }); }, 15000);
+        es.onmessage = () => {
+          if (++n >= 3) { clearTimeout(timer); es.close(); resolve({ ok: true, events: n }); }
+        };
+        es.onerror = () => { clearTimeout(timer); es.close(); resolve({ ok: false, events: n, reason: 'error' }); };
+      });
+
+      // --- BFF invariant: credentials:'include' must carry the cookie ------
+      try {
+        const res = await fetch('/whoami', { credentials: 'include' });
+        r.server_saw_cookies = await res.text();
+      } catch (e) {
+        r.server_saw_cookies = 'ERROR: ' + String(e && e.message);
+      }
+
+      // --- Cross-site credentialed request to the separate API origin ------
+      // This is production's real topology: the app on lia.jeyswork.com calls
+      // the API on lia-back.jeyswork.com. Android WebView can break it on its
+      // own — `setAcceptThirdPartyCookies` defaults to false there, unlike
+      // Chrome. The pair used here (localhost -> 127.0.0.1) is CROSS-SITE, so
+      // it is stricter than production's same-site split.
+      const apiOrigin = '__API_ORIGIN__';
+      try {
+        await fetch(apiOrigin + '/set', { credentials: 'include' });
+        const echo = await fetch(apiOrigin + '/echo', { credentials: 'include' });
+        r.api_origin_saw_cookies = await echo.text();
+      } catch (e) {
+        r.api_origin_saw_cookies = 'ERROR: ' + String(e && e.message);
+      }
+
+      // --- Is the CSP genuinely enforced in this WebView? ------------------
+      // A cross-origin fetch must be refused by `connect-src 'self' …`.
+      try {
+        await fetch('https://example.com/', { mode: 'no-cors' });
+        r.csp_blocks_cross_origin = false;
+      } catch {
+        r.csp_blocks_cross_origin = true;
+      }
+
+      // Cookie persistence across a cold app restart is measured by run.mjs,
+      // which relaunches the app while the server withholds `Set-Cookie` on
+      // every document after the first: `server_saw_cookies` above then tells
+      // whether the WebView's cookie store survived the restart. WKWebView's
+      // non-persistent data store silently drops cookies, and that failure is
+      // invisible until a user is signed out on every launch.
+
+      document.getElementById('out').textContent = JSON.stringify(r, null, 2);
+      await fetch('/result', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(r),
+      });
+    })();
+  </script>
+</body>

--- a/scripts/mobile-probe/run.mjs
+++ b/scripts/mobile-probe/run.mjs
@@ -1,0 +1,402 @@
+/**
+ * Run the native-WebView capability probe on one platform and assert LIA's
+ * invariants against the result.
+ *
+ * This is a GUARD, not a report. Facts that would silently break the product
+ * fail the run; facts that are immovable platform limits are recorded as
+ * evidence instead. The distinction matters: `PushManager` being absent is a
+ * WebView property the design works around, whereas the httpOnly session
+ * cookie becoming readable from JavaScript would be a security regression.
+ *
+ * Usage:
+ *   node scripts/mobile-probe/run.mjs --platform android|ios [--coep MODE]
+ *                                     [--port N] [--out FILE] [--fresh]
+ */
+
+import { execFileSync } from 'node:child_process';
+import { writeFile } from 'node:fs/promises';
+import { writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { startProbeServer, startApiOrigin, SESSION_SENTINEL, API_SENTINEL } from './server.mjs';
+import { scaffold, APP_ID, CAPACITOR_VERSION } from './scaffold.mjs';
+
+const WIN = process.platform === 'win32';
+
+/**
+ * How long the first launch runs before the cold restart.
+ *
+ * 60 s, and the value is EVIDENCE rather than a guess. Measured on Android 16 /
+ * WebView 133: a restart ~28 s after the cookie was set loses it, the same
+ * restart at 60 s keeps it. Chromium's WebView writes its cookie store to disk
+ * on a ~30 s timer, and Capacitor calls `CookieManager.flush()` nowhere in its
+ * lifecycle (the only flush lives inside the disabled CapacitorCookies plugin).
+ *
+ * The product consequence is real and must be fixed natively, not here: a user
+ * who signs in and leaves within that window is signed out — which is exactly
+ * when someone is most likely to background the app. The shell therefore owes a
+ * `CookieManager.getInstance().flush()` on pause. Lower this value with
+ * `--settle` to reproduce the hazard on demand.
+ */
+const FIRST_RUN_SETTLE_MS = 60_000;
+
+/**
+ * Parse `--key value` and `--flag` arguments.
+ *
+ * @param {string[]} argv - Arguments after the script name.
+ * @returns {Record<string, string|boolean>} Parsed options.
+ */
+function parseArgs(argv) {
+  const out = {};
+  for (let i = 0; i < argv.length; i += 1) {
+    if (!argv[i].startsWith('--')) continue;
+    const key = argv[i].slice(2);
+    const next = argv[i + 1];
+    if (next && !next.startsWith('--')) {
+      out[key] = next;
+      i += 1;
+    } else {
+      out[key] = true;
+    }
+  }
+  return out;
+}
+
+/**
+ * Node refuses to spawn `.bat`/`.cmd` without a shell (CVE-2024-27980), and a
+ * shell resolves the command against PATH rather than `cwd` — which is why a
+ * bare `gradlew.bat` is not found. Quote the (absolute) path and use a shell
+ * only for those two extensions.
+ *
+ * @param {string} cmd - Executable path or PATH-resolvable name.
+ * @returns {{command: string, shell: boolean}} Spawn arguments.
+ */
+function spawnable(cmd) {
+  const shell = WIN && /\.(cmd|bat)$/i.test(cmd);
+  return { command: shell ? `"${cmd}"` : cmd, shell };
+}
+
+/** Run a command, inheriting stdio, failing the process on a non-zero exit. */
+function sh(cmd, args, cwd) {
+  const { command, shell } = spawnable(cmd);
+  return execFileSync(command, args, { cwd, stdio: 'inherit', shell });
+}
+
+/** Run a command and capture its stdout. */
+function shOut(cmd, args) {
+  const { command, shell } = spawnable(cmd);
+  return execFileSync(command, args, { encoding: 'utf8', shell });
+}
+
+/**
+ * Build, install and launch the Android shell.
+ *
+ * @param {string} projectRoot - Generated Capacitor project.
+ * @param {number} port - Probe server port to forward into the device.
+ * @returns {() => void} Callback that cold-restarts the app.
+ */
+function driveAndroid(projectRoot, port, apiPort) {
+  const sdk = process.env.ANDROID_HOME || process.env.ANDROID_SDK_ROOT;
+  if (!sdk) throw new Error('ANDROID_HOME (or ANDROID_SDK_ROOT) must be set');
+
+  const androidDir = join(projectRoot, 'android');
+
+  // Forward slashes on purpose: a backslash-escaped Windows path in
+  // local.properties makes Gradle fail during dependency resolution with an
+  // opaque "syntax of the file name, directory or volume is incorrect".
+  writeFileSync(
+    join(androidDir, 'local.properties'),
+    `sdk.dir=${sdk.replace(/\\/g, '/')}\n`,
+    'utf8'
+  );
+
+  sh(
+    join(androidDir, WIN ? 'gradlew.bat' : 'gradlew'),
+    ['assembleDebug', '--no-daemon', '-q'],
+    androidDir
+  );
+
+  const apk = join(androidDir, 'app', 'build', 'outputs', 'apk', 'debug', 'app-debug.apk');
+
+  // The probe server listens on the HOST; `adb reverse` makes the device's own
+  // localhost reach it, which keeps the page in a secure context (Service
+  // Workers and cross-origin isolation both require one).
+  sh('adb', ['reverse', `tcp:${port}`, `tcp:${port}`]);
+  // The separate API origin needs its own tunnel, or the cross-site credentialed
+  // check would fail for a network reason rather than a cookie-policy one.
+  sh('adb', ['reverse', `tcp:${apiPort}`, `tcp:${apiPort}`]);
+  sh('adb', ['install', '-r', apk]);
+
+  const launch = () => sh('adb', ['shell', 'am', 'start', '-n', `${APP_ID}/.MainActivity`]);
+  launch();
+
+  return restartMode => {
+    // Android WebView writes its cookie store to disk lazily, and Capacitor
+    // never calls `CookieManager.flush()` in any lifecycle callback (verified
+    // in @capacitor/android: the only flush lives inside the disabled
+    // CapacitorCookies plugin). So HOW the app dies decides whether a session
+    // survives — which is exactly what these two modes separate.
+    if (restartMode === 'pause') {
+      sh('adb', ['shell', 'input', 'keyevent', 'KEYCODE_HOME']);
+      sh('adb', ['shell', 'sleep', '3']);
+    }
+    sh('adb', ['shell', 'am', 'force-stop', APP_ID]);
+    launch();
+  };
+}
+
+/**
+ * Build, install and launch the iOS shell on a booted simulator.
+ *
+ * @param {string} projectRoot - Generated Capacitor project.
+ * @returns {() => void} Callback that cold-restarts the app.
+ */
+function driveIos(projectRoot) {
+  const iosDir = join(projectRoot, 'ios', 'App');
+  const derived = join(projectRoot, 'ios-build');
+
+  // Capacitor 8 generates an .xcodeproj with Swift Package Manager
+  // (CapApp-SPM/Package.swift) — there is NO .xcworkspace, and CocoaPods is not
+  // involved. Verified against a generated project rather than assumed.
+  const project = join(iosDir, 'App.xcodeproj');
+
+  // The generated project ships no SHARED scheme: schemes are created under
+  // xcuserdata the first time Xcode opens it, which never happens on a runner.
+  // Ask xcodebuild what exists and fall back to the target, instead of failing
+  // with "scheme App not found" after a successful checkout.
+  let selector = ['-target', 'App'];
+  try {
+    const listed = JSON.parse(shOut('xcodebuild', ['-list', '-project', project, '-json']));
+    if (listed.project?.schemes?.includes('App')) {
+      selector = ['-scheme', 'App'];
+    }
+  } catch {
+    // `-list` can fail on a project with no schemes at all; the target selector
+    // is the safe default, so keep going.
+  }
+
+  sh('xcodebuild', [
+    '-project',
+    project,
+    ...selector,
+    '-sdk',
+    'iphonesimulator',
+    '-configuration',
+    'Debug',
+    '-derivedDataPath',
+    derived,
+    'CODE_SIGNING_ALLOWED=NO',
+    'CODE_SIGNING_REQUIRED=NO',
+    'build',
+  ]);
+
+  // Pick the newest available iPhone simulator rather than hard-coding a name:
+  // the runner image's device list changes with every Xcode release, and a
+  // stale name fails as "device not found" long after the build succeeded.
+  const listed = JSON.parse(shOut('xcrun', ['simctl', 'list', 'devices', 'available', '--json']));
+  const candidates = Object.entries(listed.devices)
+    .filter(([runtime]) => runtime.includes('iOS'))
+    .flatMap(([, devices]) => devices)
+    .filter(device => device.name.startsWith('iPhone'));
+  if (candidates.length === 0) throw new Error('no available iPhone simulator on this runner');
+  const udid = candidates[candidates.length - 1].udid;
+
+  try {
+    sh('xcrun', ['simctl', 'boot', udid]);
+  } catch {
+    // Already booted: simctl exits non-zero, which is not a failure here.
+  }
+  sh('xcrun', ['simctl', 'bootstatus', udid]);
+
+  const app = join(derived, 'Build', 'Products', 'Debug-iphonesimulator', 'App.app');
+  sh('xcrun', ['simctl', 'install', udid, app]);
+
+  const launch = () => sh('xcrun', ['simctl', 'launch', udid, APP_ID]);
+  launch();
+
+  return restartMode => {
+    if (restartMode === 'pause') {
+      // Send the app to the background so WKWebView commits its data store,
+      // mirroring the Android `pause` mode. simctl has no "press home", so this
+      // foregrounds SpringBoard instead — best effort by nature, hence the
+      // catch: a failure here must degrade the run to a plain kill, never abort
+      // it and lose every other measurement.
+      try {
+        sh('xcrun', ['simctl', 'launch', udid, 'com.apple.springboard']);
+        sh('sh', ['-c', 'sleep 3']);
+      } catch {
+        console.warn('could not background the app; falling back to a direct kill');
+      }
+    }
+    try {
+      sh('xcrun', ['simctl', 'terminate', udid, APP_ID]);
+    } catch {
+      // Not running — nothing to terminate.
+    }
+    launch();
+  };
+}
+
+/**
+ * Invariants that must hold, or the shell architecture is unsound.
+ *
+ * @param {object} first - Result of the first launch.
+ * @param {object} second - Result of the cold restart.
+ * @param {'pause'|'kill'} restartMode - How the app was terminated in between.
+ * @returns {{name: string, ok: boolean, detail: string}[]} Ordered checks.
+ */
+function assertions(first, second, restartMode) {
+  return [
+    {
+      name: 'native bridge injected under the production CSP',
+      ok: first.bridge_Capacitor === 'object' && first.bridge_isNative === true,
+      detail: `Capacitor=${first.bridge_Capacitor} isNative=${first.bridge_isNative}`,
+    },
+    {
+      name: 'httpOnly session cookie stays invisible to JavaScript',
+      ok: !String(first.document_cookie).includes('lia_session'),
+      detail: `document.cookie=${JSON.stringify(first.document_cookie)}`,
+    },
+    {
+      name: "credentials:'include' carries the session cookie (BFF contract)",
+      ok: String(first.server_saw_cookies).includes(SESSION_SENTINEL),
+      detail: String(first.server_saw_cookies),
+    },
+    {
+      name: `session cookie survives a cold restart (${restartMode})`,
+      ok: String(second.server_saw_cookies).includes(SESSION_SENTINEL),
+      detail: String(second.server_saw_cookies),
+    },
+    {
+      // Production splits web and API across two origins, so this is the path
+      // every authenticated call actually takes. Capacitor enables third-party
+      // cookies unconditionally (Bridge.create → MockCordovaWebViewImpl.init →
+      // CapacitorCordovaCookieManager → setAcceptThirdPartyCookies(true)); this
+      // assertion is what catches that call ever going away.
+      name: 'cross-site credentialed call to the separate API origin keeps its cookie',
+      ok: String(first.api_origin_saw_cookies).includes(API_SENTINEL),
+      detail: String(first.api_origin_saw_cookies),
+    },
+    {
+      name: 'SSE streams (the chat rail depends on it)',
+      ok: first.sse?.ok === true,
+      detail: JSON.stringify(first.sse),
+    },
+    {
+      name: 'Service Worker registers (offline shell, ADR-146)',
+      ok: first.sw_registered === true,
+      detail: `scope=${first.sw_scope ?? first.sw_error}`,
+    },
+    {
+      name: 'the production CSP is genuinely enforced in this WebView',
+      ok: first.csp_blocks_cross_origin === true,
+      detail: `cross-origin fetch blocked=${first.csp_blocks_cross_origin}`,
+    },
+    {
+      name: 'voice and geolocation APIs are reachable',
+      ok: first.has_getUserMedia === true && first.has_geolocation === true,
+      detail: `getUserMedia=${first.has_getUserMedia} geolocation=${first.has_geolocation}`,
+    },
+  ];
+}
+
+/**
+ * Platform limits recorded as evidence: they shape the design, not the verdict.
+ *
+ * @param {object} result - First-run probe result.
+ * @returns {Record<string, boolean>} Limits observed on this engine.
+ */
+function platformLimits(result) {
+  return {
+    // No Push API in either WebView → push must be native on BOTH platforms.
+    web_push_unavailable: result.has_Notification === false && result.has_PushManager === false,
+    // No cross-origin isolation → no SharedArrayBuffer → sherpaKws degrades to
+    // tap-to-speak. Measured false even under COEP `require-corp`.
+    cross_origin_isolation_unavailable: result.crossOriginIsolated === false,
+    wake_word_unavailable: result.has_SharedArrayBuffer === false,
+  };
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const platform = args.platform;
+  if (platform !== 'android' && platform !== 'ios') {
+    throw new Error('--platform must be "android" or "ios"');
+  }
+
+  const port = Number(args.port || 8787);
+  const apiPort = Number(args['api-port'] || port + 1);
+  // Bound to 127.0.0.1 while the document is served from localhost: the two are
+  // distinct SITES, so this exercises a stricter case than production's
+  // same-site lia./lia-back. split.
+  const apiUrl = `http://127.0.0.1:${apiPort}`;
+  const outPath = args.out || join(tmpdir(), `lia-webview-probe-${platform}.json`);
+  const timeoutMs = Number(args.timeout || 300_000);
+  const settleMs = Number(args.settle || FIRST_RUN_SETTLE_MS);
+
+  // `pause` is the default because it is what actually happens to a real app:
+  // the OS calls onPause/willResignActive before reclaiming it. `kill` is the
+  // adversarial case (a crash, or "force stop" from Settings) and is measured
+  // separately rather than asserted, since no app can prevent an abrupt SIGKILL.
+  const restartMode = args.restart === 'kill' ? 'kill' : 'pause';
+
+  // Two runs: the second document is served WITHOUT Set-Cookie, so it proves
+  // the WebView's cookie store survived a cold restart.
+  const server = await startProbeServer({ port, coep: args.coep, expected: 2, apiUrl });
+  const apiOrigin = await startApiOrigin(apiPort);
+  console.log(`probe server on ${port}, API origin on ${apiPort}`);
+
+  try {
+    const projectRoot = await scaffold(platform, `http://localhost:${port}`, Boolean(args.fresh));
+    const relaunch =
+      platform === 'android'
+        ? driveAndroid(projectRoot, port, apiPort)
+        : driveIos(projectRoot);
+
+    const runs = await Promise.race([
+      (async () => {
+        await new Promise(resolve => setTimeout(resolve, settleMs));
+        relaunch(restartMode);
+        return server.results;
+      })(),
+      new Promise((_, reject) => {
+        setTimeout(() => reject(new Error(`probe timed out after ${timeoutMs} ms`)), timeoutMs);
+      }),
+    ]);
+
+    const [first, second] = runs;
+    const checks = assertions(first, second, restartMode);
+    const failed = checks.filter(check => !check.ok);
+
+    const evidence = {
+      platform,
+      capacitor: CAPACITOR_VERSION,
+      coep: typeof args.coep === 'string' ? args.coep : 'default',
+      api_origin: apiUrl,
+      restart_mode: restartMode,
+      settle_ms: settleMs,
+      user_agent: first.ua,
+      runs,
+      assertions: checks,
+      platform_limits: platformLimits(first),
+      verdict: failed.length === 0 ? 'PASS' : 'FAIL',
+    };
+
+    await writeFile(outPath, `${JSON.stringify(evidence, null, 2)}\n`, 'utf8');
+
+    for (const check of checks) {
+      console.log(`${check.ok ? 'PASS' : 'FAIL'}  ${check.name}`);
+      console.log(`      ${check.detail}`);
+    }
+    console.log(`\nrecorded platform limits: ${JSON.stringify(evidence.platform_limits)}`);
+    console.log(`evidence written to ${outPath}`);
+
+    if (failed.length > 0) process.exitCode = 1;
+  } finally {
+    await server.close();
+    await apiOrigin.close();
+  }
+}
+
+await main();

--- a/scripts/mobile-probe/scaffold.mjs
+++ b/scripts/mobile-probe/scaffold.mjs
@@ -1,0 +1,154 @@
+/**
+ * Scaffold the throwaway Capacitor shell the probe runs inside.
+ *
+ * The native project is GENERATED, never vendored: committing an Android or
+ * Xcode project would add thousands of files the repo cannot review, and would
+ * freeze the very thing the probe exists to re-measure. It is built into the
+ * OS temp directory so `task deploy:prod` — which rsyncs the WORKING TREE,
+ * untracked files included — can never ship it.
+ */
+
+import { mkdir, writeFile, readFile, rm } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+/**
+ * Capacitor version the measurements were taken against.
+ *
+ * Pinned exactly: this harness is a non-regression guard, and a floating range
+ * would let a silent upgrade change the answer without changing the evidence.
+ * Bumping it is a deliberate act that must be followed by a fresh run.
+ */
+export const CAPACITOR_VERSION = '8.5.0';
+
+/** Application id of the throwaway shell. */
+export const APP_ID = 'com.lia.webviewprobe';
+
+/**
+ * Create (or reuse) the Capacitor project for one platform.
+ *
+ * @param {'android'|'ios'} platform - Native platform to add.
+ * @param {string} serverUrl - URL the WebView loads (the probe server).
+ * @param {boolean} fresh - Delete any existing project first.
+ * @returns {Promise<string>} Absolute path of the generated project.
+ */
+export async function scaffold(platform, serverUrl, fresh = false) {
+  const root = join(tmpdir(), `lia-webview-probe-${platform}`);
+
+  if (fresh && existsSync(root)) {
+    await rm(root, { recursive: true, force: true });
+  }
+
+  // Node refuses to spawn `.cmd` without a shell (CVE-2024-27980); npm and npx
+  // ship as `.cmd` shims on Windows, so name them explicitly there.
+  const win = process.platform === 'win32';
+  const run = (cmd, args) =>
+    execFileSync(win ? `${cmd}.cmd` : cmd, args, { cwd: root, stdio: 'inherit', shell: win });
+
+  const isNew = !existsSync(join(root, 'node_modules'));
+  await mkdir(join(root, 'www'), { recursive: true });
+
+  await writeFile(
+    join(root, 'package.json'),
+    `${JSON.stringify({ name: 'lia-webview-probe', version: '0.0.0', private: true }, null, 2)}\n`
+  );
+
+  // Capacitor requires a webDir even when it loads a remote URL; this file is
+  // never displayed, because `server.url` wins.
+  await writeFile(
+    join(root, 'www', 'index.html'),
+    '<!doctype html><meta charset="utf-8"><title>unused</title>\n'
+  );
+
+  await writeFile(
+    join(root, 'capacitor.config.json'),
+    `${JSON.stringify(
+      {
+        appId: APP_ID,
+        appName: 'LIAWebViewProbe',
+        webDir: 'www',
+        // cleartext: the probe server is plain HTTP on `localhost`, which is a
+        // secure context in both engines — the only way to exercise Service
+        // Workers and cross-origin isolation without provisioning a certificate.
+        server: { url: serverUrl, cleartext: true },
+        // Left at their defaults (false) ON PURPOSE, and asserted by run.mjs:
+        // enabling either replaces window.fetch / document.cookie for the whole
+        // application, which would silently break LIA's BFF cookie contract.
+        plugins: { CapacitorHttp: { enabled: false }, CapacitorCookies: { enabled: false } },
+      },
+      null,
+      2
+    )}\n`
+  );
+
+  if (isNew) {
+    run('npm', [
+      'install',
+      '--silent',
+      '--no-audit',
+      '--no-fund',
+      `@capacitor/core@${CAPACITOR_VERSION}`,
+      `@capacitor/cli@${CAPACITOR_VERSION}`,
+      `@capacitor/${platform}@${CAPACITOR_VERSION}`,
+    ]);
+  }
+
+  if (!existsSync(join(root, platform))) {
+    run('npx', ['cap', 'add', platform]);
+  } else {
+    run('npx', ['cap', 'sync', platform]);
+  }
+
+  if (platform === 'ios') {
+    await allowLocalhostOverHttp(join(root, 'ios', 'App', 'App', 'Info.plist'));
+  }
+
+  return root;
+}
+
+/**
+ * Let the iOS shell load the probe server over plain HTTP on `localhost`.
+ *
+ * `server.cleartext` is an ANDROID-only option (it maps to
+ * `usesCleartextTraffic`); Capacitor's iOS platform ignores it, and the
+ * generated Info.plist carries no `NSAppTransportSecurity` key at all. Whether
+ * App Transport Security tolerates loopback HTTP has varied across iOS
+ * releases, so the exception is declared rather than relied upon — a probe must
+ * not fail for a reason unrelated to what it measures.
+ *
+ * Scoped to `localhost`. `NSAllowsArbitraryLoads` would disable ATS for the
+ * whole app, which is never an acceptable shape to copy into a shipping shell.
+ *
+ * @param {string} plistPath - Path of the generated Info.plist.
+ */
+export async function allowLocalhostOverHttp(plistPath) {
+  const plist = await readFile(plistPath, 'utf8');
+  if (plist.includes('NSAppTransportSecurity')) return;
+
+  const exception = [
+    '\t<key>NSAppTransportSecurity</key>',
+    '\t<dict>',
+    '\t\t<key>NSAllowsLocalNetworking</key>',
+    '\t\t<true/>',
+    '\t\t<key>NSExceptionDomains</key>',
+    '\t\t<dict>',
+    '\t\t\t<key>localhost</key>',
+    '\t\t\t<dict>',
+    '\t\t\t\t<key>NSExceptionAllowsInsecureHTTPLoads</key>',
+    '\t\t\t\t<true/>',
+    '\t\t\t</dict>',
+    '\t\t</dict>',
+    '\t</dict>',
+    '</dict>',
+  ].join('\n');
+
+  // Tolerate CRLF and trailing whitespace: the file is generated by the
+  // Capacitor CLI, which may run on either host.
+  const closing = /<\/dict>\s*<\/plist>\s*$/;
+  if (!closing.test(plist)) {
+    throw new Error(`unexpected Info.plist shape: ${plistPath}`);
+  }
+  await writeFile(plistPath, plist.replace(closing, `${exception}\n</plist>\n`), 'utf8');
+}

--- a/scripts/mobile-probe/server.mjs
+++ b/scripts/mobile-probe/server.mjs
@@ -1,0 +1,202 @@
+/**
+ * Measurement server for the native-WebView capability probe.
+ *
+ * It serves `page.html` under LIA's REAL production security headers. Those
+ * headers are IMPORTED from `apps/web/src/lib/csp.ts` — the same pure module
+ * `next.config.ts` and `csp.test.ts` use — so the probe can never drift from
+ * what production actually serves. Copying the policy here would recreate
+ * exactly the duplication that module exists to prevent.
+ *
+ * The probe page POSTs its findings to `/result`; `run.mjs` awaits them.
+ *
+ * `Set-Cookie` is emitted on the FIRST document only. A second app launch
+ * therefore proves whether the WebView's cookie store survived a cold restart:
+ * a non-persistent store (WKWebView's default when misconfigured) silently
+ * signs the user out on every launch, and nothing else surfaces it.
+ */
+
+import { createServer } from 'node:http';
+import { readFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+import { buildAppCsp, resolveCoepMode, buildHsts } from '../../apps/web/src/lib/csp.ts';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+
+/** Sentinel session value: proves the server received the httpOnly cookie. */
+export const SESSION_SENTINEL = 'probe-session-sentinel';
+
+/** Cookie name LIA uses in production (`SecuritySettings.session_cookie_name`). */
+const SESSION_COOKIE = 'lia_session';
+
+/** Sentinel for the cross-site API cookie (see the API server below). */
+export const API_SENTINEL = 'probe-api-sentinel';
+
+/**
+ * Build the production response headers for a probe document.
+ *
+ * @param {string|undefined} coepRaw - Value to resolve through `resolveCoepMode`.
+ * @param {string} apiUrl - Separate API origin, as `NEXT_PUBLIC_API_URL` in
+ *   production (`https://lia-back.…` next to the web app on `https://lia.…`).
+ *   Passing it makes `connect-src` carry that origin, exactly as production does.
+ * @returns {Record<string,string>} Header map mirroring `next.config.ts`.
+ */
+export function productionHeaders(coepRaw, apiUrl = '') {
+  return {
+    'Strict-Transport-Security': buildHsts(),
+    'X-DNS-Prefetch-Control': 'on',
+    'X-Frame-Options': 'SAMEORIGIN',
+    'X-Content-Type-Options': 'nosniff',
+    'Referrer-Policy': 'origin-when-cross-origin',
+    'Cross-Origin-Embedder-Policy': resolveCoepMode(coepRaw),
+    'Cross-Origin-Opener-Policy': 'same-origin',
+    'Content-Security-Policy': buildAppCsp(false, apiUrl),
+  };
+}
+
+/**
+ * Start the cross-site "API" origin.
+ *
+ * Production puts the API on a SEPARATE ORIGIN (`connect-src` on
+ * lia.jeyswork.com names https://lia-back.jeyswork.com), so every authenticated
+ * call is a cross-origin credentialed request — a different code path from the
+ * same-origin case, and one Android WebView can break on its own: unlike Chrome,
+ * `CookieManager.setAcceptThirdPartyCookies` defaults to FALSE there.
+ *
+ * `localhost` and `127.0.0.1` are distinct sites for cookie purposes, so this
+ * pair exercises the STRICTER case than production's same-site split — if the
+ * cookie survives here, it survives there.
+ *
+ * @param {number} port - Port to listen on (bound to 127.0.0.1).
+ * @returns {Promise<{close: () => Promise<void>}>} Handle to shut it down.
+ */
+export async function startApiOrigin(port) {
+  const cors = origin => ({
+    'Access-Control-Allow-Origin': origin,
+    'Access-Control-Allow-Credentials': 'true',
+    Vary: 'Origin',
+  });
+
+  const server = createServer((req, res) => {
+    const url = new URL(req.url, 'http://127.0.0.1');
+    const origin = req.headers.origin || '*';
+
+    if (url.pathname === '/set') {
+      res.writeHead(200, {
+        'Content-Type': 'text/plain',
+        // SameSite=None is mandatory for a cross-site credentialed cookie, and
+        // it requires Secure — which Chromium accepts on a loopback host even
+        // over plain HTTP, because loopback counts as a trustworthy origin.
+        'Set-Cookie': `api_session=${API_SENTINEL}; Path=/; HttpOnly; Secure; SameSite=None; Max-Age=3600`,
+        ...cors(origin),
+      });
+      res.end('set');
+      return;
+    }
+
+    res.writeHead(200, { 'Content-Type': 'text/plain', ...cors(origin) });
+    res.end(req.headers.cookie || '(no cookie)');
+  });
+
+  await new Promise(resolve => server.listen(port, '127.0.0.1', resolve));
+  return { close: () => new Promise(resolve => server.close(resolve)) };
+}
+
+/**
+ * Start the probe server.
+ *
+ * @param {{port?: number, coep?: string, expected?: number, apiUrl?: string}}
+ *   options - Listen port, COEP mode, how many probe runs to await, and the
+ *   separate API origin to declare in `connect-src`.
+ * @returns {Promise<{close: () => Promise<void>, results: Promise<object[]>, port: number}>}
+ */
+export async function startProbeServer({ port = 8787, coep, expected = 1, apiUrl = '' } = {}) {
+  const template = await readFile(join(HERE, 'page.html'), 'utf8');
+  const page = template.replace('__API_ORIGIN__', apiUrl);
+  const headers = productionHeaders(coep, apiUrl);
+
+  const collected = [];
+  let documentsServed = 0;
+  let resolveResults;
+  const results = new Promise(resolve => {
+    resolveResults = resolve;
+  });
+
+  const server = createServer((req, res) => {
+    const url = new URL(req.url, 'http://localhost');
+
+    if (url.pathname === '/sse') {
+      res.writeHead(200, {
+        'Content-Type': 'text/event-stream',
+        'Cache-Control': 'no-cache',
+        Connection: 'keep-alive',
+      });
+      let sent = 0;
+      const timer = setInterval(() => {
+        res.write(`data: tick ${++sent}\n\n`);
+        if (sent >= 5) {
+          clearInterval(timer);
+          res.end();
+        }
+      }, 200);
+      req.on('close', () => clearInterval(timer));
+      return;
+    }
+
+    if (url.pathname === '/sw.js') {
+      res.writeHead(200, {
+        'Content-Type': 'application/javascript',
+        'Service-Worker-Allowed': '/',
+      });
+      res.end("self.addEventListener('install', () => self.skipWaiting());\n");
+      return;
+    }
+
+    if (url.pathname === '/whoami') {
+      res.writeHead(200, { 'Content-Type': 'text/plain; charset=utf-8', ...headers });
+      res.end(req.headers.cookie || '(no cookie)');
+      return;
+    }
+
+    if (url.pathname === '/result' && req.method === 'POST') {
+      let body = '';
+      req.on('data', chunk => {
+        body += chunk;
+      });
+      req.on('end', () => {
+        res.writeHead(204, headers);
+        res.end();
+        try {
+          collected.push(JSON.parse(body));
+        } catch (error) {
+          collected.push({ parse_error: String(error), raw: body });
+        }
+        if (collected.length >= expected) {
+          resolveResults(collected);
+        }
+      });
+      return;
+    }
+
+    documentsServed += 1;
+    const documentHeaders = { 'Content-Type': 'text/html; charset=utf-8', ...headers };
+    if (documentsServed === 1) {
+      // httpOnly + Max-Age mirrors production: persistent, JS-invisible.
+      documentHeaders['Set-Cookie'] = [
+        `${SESSION_COOKIE}=${SESSION_SENTINEL}; Path=/; HttpOnly; SameSite=Lax; Max-Age=3600`,
+        'NEXT_LOCALE=fr; Path=/; SameSite=Lax; Max-Age=3600',
+      ];
+    }
+    res.writeHead(200, documentHeaders);
+    res.end(page);
+  });
+
+  await new Promise(resolve => server.listen(port, '127.0.0.1', resolve));
+
+  return {
+    port,
+    results,
+    close: () => new Promise(resolve => server.close(resolve)),
+  };
+}


### PR DESCRIPTION
Adds a permanent probe that runs LIA's web app inside a Capacitor shell and asserts what a native mobile shell must preserve — on both engines, under the **real production headers**.

## Why it lands before any mobile code

The shell architecture rests on one bet: the WebView loads the **remote web origin**, so the httpOnly session cookie, SSE and the whole BFF contract keep working unchanged. The API accepts nothing but `Cookie()` (`core/session_dependencies.py`), so that bet is not optional — and it is only worth making if it is measured.

## No drift by construction

`server.mjs` **imports** `buildAppCsp` / `resolveCoepMode` / `buildHsts` from `apps/web/src/lib/csp.ts` — the same pure module `next.config.ts` uses. Copying the policy would recreate the duplication that module exists to prevent. The probe also replays production's real topology: a **separate API origin** declared in `connect-src`, exactly as `lia.jeyswork.com` names `lia-back.jeyswork.com`.

The native project is generated into the OS temp directory, never vendored — `task deploy:prod` rsyncs the working tree, untracked files included, so a vendored Xcode project could reach production by accident.

## The nine assertions

Bridge injection under the strict CSP · httpOnly cookie invisible to JavaScript · `credentials:'include'` carries it · a **cross-site** credentialed call to the separate API origin keeps it · cold-restart persistence · SSE · Service Worker · CSP genuinely enforced · voice and geolocation reachable.

**Measured on Android 16 / WebView 133, Capacitor 8.5.0: 9/9.**

## Three platform limits recorded, not asserted

They shape the design instead of failing it:

- **No Push API in either WebView** → push must be native on **both** platforms. `UserFCMToken.device_type` already accepts `android|ios|web`, so no schema change.
- **No cross-origin isolation, hence no `SharedArrayBuffer`** → the wake word degrades to tap-to-speak. Measured false **even under COEP `require-corp`**, so it is not a header choice — it is a regression the shell must own on Android too, where the PWA has it today.

## A hazard the probe pinned down

Android WebView writes its cookie store to disk on a **~30 s timer** and Capacitor calls `CookieManager.flush()` nowhere in its lifecycle. Measured: a restart 28 s after sign-in **loses the session**; the same restart at 60 s keeps it. A user who signs in and leaves within that window is signed out — the most likely moment to background an app. The shell owes a native `flush()` on pause. Reproduce with `-- --settle 25000`.

## Scope and safety

- `.github/workflows/mobile-webview-probe.yml` is **`workflow_dispatch` only** — same shape as `installer-disposable-smoke.yml`. It touches no store, credential, or production surface.
- The iOS leg runs on a GitHub-hosted `macos-latest` runner, free for this public repository — the only way to reach WKWebView without a Mac. It is the one measurement still missing, and it unlocks the moment this merges (`workflow_dispatch` requires the file on the default branch).
- CI orchestrates, the Taskfile implements (ADR-151): both legs call `task mobile:probe:{android,ios}`.

## Verified locally before pushing

`task lint` → 0 · `task ci:fast` → 0 · `gitleaks` v8.28.0 with the repo's own `.gitleaks.toml` → 0 findings · Android probe → 9/9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
